### PR TITLE
Pandas dataframes returned by the query API are now singleton cells

### DIFF
--- a/datacommons/test/datacommons_test.py
+++ b/datacommons/test/datacommons_test.py
@@ -66,7 +66,7 @@ class AppTest(unittest.TestCase):
     }, {
         'rows': [{
             'cells': [{
-                'value': ['Oceania']
+                'value': ['Oceania', 'North America']
             }, {
                 'value': ['3292000']
             }]
@@ -74,8 +74,8 @@ class AppTest(unittest.TestCase):
         'header': ['name', 'area_sq_mi']
     })
     expected_df = pd.DataFrame({
-        'name': ['Oceania'],
-        'area_sq_mi': ['3292000']
+        'name': ['Oceania', 'North America'],
+        'area_sq_mi': ['3292000', '3292000']
     })
     expected_df = expected_df[['name', 'area_sq_mi']]
 

--- a/datacommons/test/datacommons_test.py
+++ b/datacommons/test/datacommons_test.py
@@ -74,8 +74,8 @@ class AppTest(unittest.TestCase):
         'header': ['name', 'area_sq_mi']
     })
     expected_df = pd.DataFrame({
-        'name': [['Oceania']],
-        'area_sq_mi': [['3292000']]
+        'name': ['Oceania'],
+        'area_sq_mi': ['3292000']
     })
     expected_df = expected_df[['name', 'area_sq_mi']]
 


### PR DESCRIPTION
When a property contains multiple values, this gets expanded into multiple rows in the Pandas dataframe.